### PR TITLE
scale extension scales each slide separately

### DIFF
--- a/extensions/scale/deck.scale.css
+++ b/extensions/scale/deck.scale.css
@@ -1,16 +1,16 @@
-.csstransforms .deck-container.deck-scale {
-  width: auto;
-  -webkit-transform-origin: 50% 0;
-  -moz-transform-origin: 50% 0;
-  -o-transform-origin: 50% 0;
-  -ms-transform-origin: 50% 0;
-  transform-origin: 50% 0;
+.csstransforms .deck-container.deck-scale section.slide {
+	width:auto;
+	-webkit-transform-origin: 50% 0;
+	-moz-transform-origin: 50% 0;
+	-o-transform-origin: 50% 0;
+	-ms-transform-origin: 50% 0;
+	transform-origin: 50% 0;
 }
 .csstransforms .deck-container.deck-scale.deck-menu {
-  width: 70%;
-  -webkit-transform: none !important;
-  -moz-transform: none !important;
-  -o-transform: none !important;
-  -ms-transform: none !important;
-  transform: none !important;
+	width:70%;
+	-webkit-transform:none !important;
+	-moz-transform:none !important;
+	-o-transform:none !important;
+	-ms-transform:none !important;
+	transform:none !important;
 }

--- a/extensions/scale/deck.scale.js
+++ b/extensions/scale/deck.scale.js
@@ -22,7 +22,7 @@ works fine.
 	$w = $(window),
 	baseHeight, // Value to scale against
 	timer, // Timeout id for debouncing
-	
+
 	/*
 	Internal function to do all the dirty work of scaling the deck container.
 	*/
@@ -33,105 +33,106 @@ works fine.
 		slides = $[deck]('getSlides'),
 		scale,
 		transform;
-		
+
 		// Don't scale if scaling disabled
 		if (!$container.hasClass($[deck]('getOptions').classes.scale)) {
 			scale = 1;
 		}
 		else {
-			// Use tallest slide as base height if not set manually
+			// Use window height as base height if not set manually
 			baseHeight = obh ? obh : (function() {
-				var greatest = 0;
-
-				$.each(slides, function(i, $slide) {
-					greatest = Math.max(greatest, $slide.outerHeight());
-				});
-
-				return greatest;
+				var slop = 40; /* for padding */
+			  var windowHeight = $(window).height();
+				return windowHeight - slop;
 			})();
-			
-			scale = height / baseHeight;
 		}
-		
-		// Scale, but don't scale up
-		transform = scale >= 1 ? 'none' : 'scale(' + scale + ')';
-		$.each('Webkit Moz O ms Khtml'.split(' '), function(i, prefix) {
-			$container.css(prefix + 'Transform', transform);
-		});
-	};
+
+		// Scale each slide down if necessary (but don't scale up)
+		$.each(slides, function(i, $slide) {
+		  var slideHeight = $slide.innerHeight();
+		  var scale = baseHeight / slideHeight;
+
+		  if (scale < 1) {
+		    transform = 'scale(' + scale + ')';
+  		  $.each('Webkit Moz O ms Khtml'.split(' '), function(i, prefix) {
+  			  $slide.css(prefix + 'Transform', transform);
+  		  });
+		  }
+	  });
+  }
 
 	/*
 	Extends defaults/options.
-	
+
 	options.classes.scale
 		This class is added to the deck container when scaling is enabled.
 		It is enabled by default when the module is included.
-	
+
 	options.keys.scale
 		The numeric keycode used to toggle enabling and disabling scaling.
-	
+
 	options.baseHeight
 		When baseheight is falsy, as it is by default, the deck is scaled
 		in proportion to the height of the slides.  You may instead specify
 		a height, and the deck will be scaled against this height regardless
 		of the actual content height.
-	
+
 	options.scaleDebounce
 		Scaling on the browser resize event is debounced. This number is the
 		threshold in milliseconds. You can learn more about debouncing here:
 		http://unscriptable.com/index.php/2009/03/20/debouncing-javascript-methods/
-	
+
 	*/
 	$.extend(true, $[deck].defaults, {
 		classes: {
 			scale: 'deck-scale'
 		},
-		
+
 		keys: {
 			scale: 83 // s
 		},
-		
+
 		baseHeight: null,
 		scaleDebounce: 200
 	});
-	
+
 	/*
 	jQuery.deck('disableScale')
-	
+
 	Disables scaling and removes the scale class from the deck container.
 	*/
 	$[deck]('extend', 'disableScale', function() {
 		$[deck]('getContainer').removeClass($[deck]('getOptions').classes.scale);
 		scaleDeck();
 	});
-	
+
 	/*
 	jQuery.deck('enableScale')
-	
+
 	Enables scaling and adds the scale class to the deck container.
 	*/
 	$[deck]('extend', 'enableScale', function() {
 		$[deck]('getContainer').addClass($[deck]('getOptions').classes.scale);
 		scaleDeck();
 	});
-	
+
 	/*
 	jQuery.deck('toggleScale')
-	
+
 	Toggles between enabling and disabling scaling.
 	*/
 	$[deck]('extend', 'toggleScale', function() {
 		var $c = $[deck]('getContainer');
 		$[deck]($c.hasClass($[deck]('getOptions').classes.scale) ?
-			'disableScale' : 'enableScale'); 
+			'disableScale' : 'enableScale');
 	});
 
 	$d.bind('deck.init', function() {
 		var opts = $[deck]('getOptions');
-		
+
 		// Scaling enabled at start
 		$[deck]('getContainer').addClass(opts.classes.scale);
-		
+
 		// Debounce the resize scaling
 		$w.unbind('resize.deckscale').bind('resize.deckscale', function() {
 			window.clearTimeout(timer);
@@ -139,7 +140,7 @@ works fine.
 		})
 		// Scale once on load, in case images or something change layout
 		.unbind('load.deckscale').bind('load.deckscale', scaleDeck);
-		
+
 		// Bind key events
 		$d.unbind('keydown.deckscale').bind('keydown.deckscale', function(e) {
 			if (e.which === opts.keys.scale || $.inArray(e.which, opts.keys.scale) > -1) {
@@ -147,7 +148,7 @@ works fine.
 				e.preventDefault();
 			}
 		});
-		
+
 		// Scale once on init
 		scaleDeck();
 	});

--- a/extensions/scale/deck.scale.scss
+++ b/extensions/scale/deck.scale.scss
@@ -1,10 +1,12 @@
 .csstransforms .deck-container.deck-scale {
-	width:auto;
-	-webkit-transform-origin: 50% 0;
-	-moz-transform-origin: 50% 0;
-	-o-transform-origin: 50% 0;
-	-ms-transform-origin: 50% 0;
-	transform-origin: 50% 0;
+	section.slide {
+		width:auto;
+		-webkit-transform-origin: 50% 0;
+		-moz-transform-origin: 50% 0;
+		-o-transform-origin: 50% 0;
+		-ms-transform-origin: 50% 0;
+		transform-origin: 50% 0;
+	}
 	
 	&.deck-menu {
 		width:70%;


### PR DESCRIPTION
The "scale" extension didn't work so well when only a few slides were really tall. It shrunk all slides as if they were as tall as the tallest one, ending up with really tiny text on all of them, not just the ones that spilled over. This patch scales each slide independently of the others, and only if necessary.

It "works for me" but here are some thoughts for possible improvement:
- There were no unit tests for the actual scaling, so all tests continue to pass. It can be hard to test sizing stuff using Jasmine so I didn't want to open that can of worms without checking with you first.
- It uses the window height as the default baseHeight (minus a "slop" of 40 pixels so scaled slides don't bleed all the way to the edge) but it might well work using $slide.outerHeight() -- it looks like Chrome at least sets outerHeight to be the visible height and innerHeight to be the full height of the content, which means that for slides taller than the window the inner height is _greater_ than the outer height. I haven't checked this on all browsers so I'm sticking with windowHeight even though that cuts off the possibility of using this with decks whose container is not BODY.
- Scaled slides may have different-sized headers (H2 text) than their siblings which might violate your aesthetic sense. I can imagine a system that wraps a div around all content following the first H2 and scales that, but that seems pretty kludgey and not worth the effort.
- I edited, but didn't test, the .scss file, since I'm just using the .css file and didn't see any tools for compiling the .scss in the project (though I admit I didn't look very hard).
- So far I've only tested it with the Swiss theme.
