### PR TITLE
rescale after MathJax startup process has completed

### DIFF
--- a/extensions/scale/deck.scale.js
+++ b/extensions/scale/deck.scale.js
@@ -162,6 +162,12 @@ works fine.
 				e.preventDefault();
 			}
 		});
+		
+		// rescale after MathJax startup process has completed
+		if(typeof(MathJax)==="object") MathJax.Hub.Register.StartupHook("End",function () {
+			window.clearTimeout(timer);
+			timer = window.setTimeout(scaleDeck, opts.scaleDebounce);
+		});		
 
 		// Enable scale on init
 		$[deck]('enableScale');


### PR DESCRIPTION
Hi, 

I made this small adjustment to deck.rescale.js. It rescales the deck after MathJax is done with rendering the math formula. Currently, deck.js rescales before MathJax is done, which does not take into account the space formulas take in the deck. As a consequence, content might be pushed out of the visible region after the formatting of formulas. With this addition, deck.js rescales after MathJax is done with formatting solving this problem. The additional rescaling only happens if typeof(MathJax)==="object" so that it has no effect for people who are not using MathJax.

I am not sure whether this is of general interest but I thought I will share it. So feel free to reject the pull request  if you think that it should not be part of deck.js...
