### PR TITLE
Prevent holding down key from advancing slide

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -171,15 +171,22 @@ that use the API provided by core.
 				});
 			}
 			
+			var keyboardNavigationTimeout;
 			/* Remove any previous bindings, and rebind key events */
 			$d.unbind('keydown.deck').bind('keydown.deck', function(e) {
+				var action = null;
 				if (e.which === options.keys.next || $.inArray(e.which, options.keys.next) > -1) {
-					methods.next();
-					e.preventDefault();
+					action = 'next';
 				}
 				else if (e.which === options.keys.previous || $.inArray(e.which, options.keys.previous) > -1) {
-					methods.prev();
+					action = 'prev';
+				}
+				if(action){
 					e.preventDefault();
+					clearTimeout(keyboardNavigationTimeout);
+					keyboardNavigationTimeout = setTimeout(function(){
+						methods[action]();
+					}, 100);
 				}
 			})
 			/* Stop propagation of key events within editable elements */


### PR DESCRIPTION
I noticed in use of this code that holding down the arrow or other next/prev keys that the slides would sometimes get into a loop where the hash tag url would keep advancing and the slides would keep updating. (Using the deck.hash.js plugin.) This is easily preventable by setting a timeout on firing the next slide. 100 ms is still fast enough that mashing the key manually advances the slides quickly, but holding it down doesn't advance more than one.
