### PR TITLE
integrate remote control for slides

### DIFF
--- a/boilerplate.html
+++ b/boilerplate.html
@@ -85,6 +85,7 @@
 <script src="extensions/status/deck.status.js"></script>
 <script src="extensions/navigation/deck.navigation.js"></script>
 <script src="extensions/scale/deck.scale.js"></script>
+<script src="extensions/remotes/deck.remotes.js"></script>
 
 <!-- Initialize the deck. You can put this in an external file if desired. -->
 <script>

--- a/extensions/remotes/deck.remotes.js
+++ b/extensions/remotes/deck.remotes.js
@@ -1,0 +1,25 @@
+/*!
+Deck JS - deck.remotes
+Copyright (c) 2013 Philip Nuzhnyi https://github.com/callmephilip
+*/
+
+(function($, deck, undefined) {
+    var $d = $(document),
+    remotesLibPath = 'https://raw.github.com/Remotes/Remotes/master/dist/remotes.ne.min.js';
+    
+    //do NOT load the extension on touch devices
+    if(!Modernizr.touch){
+        Modernizr.load([
+            {
+                load: remotesLibPath,
+                complete: function () {
+                    new Remotes("preview")
+                        .on("swipe-left", function(e){ $[deck]('next'); })
+                        .on("swipe-right", function(e){ $[deck]('prev'); })
+                        .on("tap", function(e){ $[deck]('next'); });
+                }
+            }
+        ]);
+    }
+
+})(jQuery, 'deck');


### PR DESCRIPTION
Phone based remote control for the slide deck. Navigation using swipes on the mobile device (left swipe takes you to the next slide, right swipe goes to the previous slide, tap advances to the next slide). Sync is done via qr code (subject to change in the future). Uses [remotes.io](http://remotes.io).

Here's a [demo](https://dl.dropbox.com/u/9224326/www/deckjs/boilerplate.html). 
