### PR TITLE
[menu] preventing menu toggle when Ctrl is pressed 

### DIFF
--- a/extensions/menu/deck.menu.js
+++ b/extensions/menu/deck.menu.js
@@ -149,6 +149,7 @@ on the deck container.
 		// Bind key events
 		$d.unbind('keydown.deckmenu').bind('keydown.deckmenu', function(e) {
 			if (e.which === opts.keys.menu || $.inArray(e.which, opts.keys.menu) > -1) {
+				if (e.ctrlKey) return;
 				$[deck]('toggleMenu');
 				e.preventDefault();
 			}


### PR DESCRIPTION
(e.g., for Ctrl+Shift...+M for responsive design view)

as discussed.
