### PR TITLE
removing horizontal-only padding from the deck-container (themes)

### DIFF
--- a/themes/style/_reset.scss
+++ b/themes/style/_reset.scss
@@ -288,7 +288,7 @@ li {
 }
 
 .deck-container {
-  padding:0 48px;
+  padding:0;
   font-size:16px;
   line-height:1.25;
   color:#444;

--- a/themes/style/neon.css
+++ b/themes/style/neon.css
@@ -279,7 +279,7 @@ li > ol, li > ul {
 }
 
 .deck-container {
-  padding: 0 48px;
+  padding: 0;
   font-size: 16px;
   line-height: 1.25;
   color: #444;

--- a/themes/style/swiss.css
+++ b/themes/style/swiss.css
@@ -279,7 +279,7 @@ li > ol, li > ul {
 }
 
 .deck-container {
-  padding: 0 48px;
+  padding: 0;
   font-size: 16px;
   line-height: 1.25;
   color: #444;

--- a/themes/style/web-2.0.css
+++ b/themes/style/web-2.0.css
@@ -280,7 +280,7 @@ li > ol, li > ul {
 }
 
 .deck-container {
-  padding: 0 48px;
+  padding: 0;
   font-size: 16px;
   line-height: 1.25;
   color: #444;


### PR DESCRIPTION
There was a padding (horziontal only) for the .deck-container in the reset css. I feel container should have have this padding by default. It also "breaks" the fit extension.

NB: the "make" changes more (e.g. #ccc -> #cccccc) so I commited only the relevant changes.
