### PR TITLE
Filling array of slides also before pre-init event

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -283,8 +283,12 @@ that use the API provided by core.
       // Hide the deck while states are being applied to kill transitions
       $container.addClass(options.classes.loading);
 
+      // populate the array of slides for pre-init
+      initSlidesArray(elements);
       // Pre init event for preprocessing hooks
       beforeInitEvent.done = function() {
+        // re-populate the array of slides
+        slides = [];
         initSlidesArray(elements);
         bindKeyEvents();
         bindTouchEvents();


### PR DESCRIPTION
To allow extensions (e.g. async loading/processing) to use the list of slides in the preInitialize callback, the array is filled before this event (and filled again before the initialize callback).
