### PR TITLE
fix possible double call to "beforeInitEvent.done()"

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -411,10 +411,9 @@ that use the API provided by core.
         $document.trigger(events.initialize);
       };
 
+      beforeInitEvent.lockInit();
       $document.trigger(beforeInitEvent);
-      if (!beforeInitEvent.locks) {
-        beforeInitEvent.done();
-      }
+      beforeInitEvent.releaseInit();
       window.setTimeout(function() {
         if (beforeInitEvent.locks) {
           if (window.console) {


### PR DESCRIPTION
now surrounding beforeInitEvent notification with lockInit/releaseInit:
- done() will be called as before (but with removed duplicate logic)
- done() will not risk of being called twice (this actually happened when a beforeInitEvent trigger was locking and releasing the event fast)
