### PR TITLE
fix: goto was not going to the last slide when countNested=false

### DIFF
--- a/extensions/goto/deck.goto.js
+++ b/extensions/goto/deck.goto.js
@@ -78,7 +78,7 @@ the deck container.
       var index = parseInt(indexOrId, 10);
 
       if (!options.countNested) {
-        if (!isNaN(index) && index >= rootCounter) {
+        if (!isNaN(index) && (index > rootCounter || index <= 0)) {
           return false;
         }
         $.each($.deck('getSlides'), function(i, $slide) {


### PR DESCRIPTION
- changed >= to > for the fix
- also checking for non-positive values
