### PR TITLE
Fix: Register hashchange event more cautiously.

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -596,6 +596,16 @@ that use the API provided by core.
 
   /* jQuery extension */
   $.deck = function(method, arg) {
+    
+    $window.bind('hashchange.deck', function(event) {
+      if (event.originalEvent && event.originalEvent.newURL) {
+        goByHash(event.originalEvent.newURL);
+      }
+      else {
+        goByHash(window.location.hash);
+      }
+    });
+
     var args = Array.prototype.slice.call(arguments, 1);
     if (methods[method]) {
       return methods[method].apply(this, args);
@@ -729,15 +739,6 @@ that use the API provided by core.
 
   $document.ready(function() {
     $('html').addClass('ready');
-  });
-
-  $window.bind('hashchange.deck', function(event) {
-    if (event.originalEvent && event.originalEvent.newURL) {
-      goByHash(event.originalEvent.newURL);
-    }
-    else {
-      goByHash(window.location.hash);
-    }
   });
 
   $window.bind('load.deck', function() {


### PR DESCRIPTION
Registering a callback for the "hashchange" event should not occur, before the $.deck plugin was used by the consumer. Otherwise it will be executed, even if there are no slides to actually operate on.

I experienced this behaviour (let's call it a bug) in an app where hash changes did occur before the deck plugin was initialised. This seems to be limited to single page apps, where a dependency can be loaded, before `$.deck( ... )` was being called.
