### PR TITLE
ignoring (arrow) keys when the ALT key is pressed

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -185,6 +185,11 @@ that use the API provided by core.
     ].join(', ');
 
     $document.unbind('keydown.deck').bind('keydown.deck', function(event) {
+      if (event.altKey) {
+        // ignore events when the ALT key is down
+        // NB: browsers use ALT+arrow to navigate history
+        return;
+      }
       var isNext = event.which === options.keys.next;
       var isPrev = event.which === options.keys.previous;
       isNext = isNext || $.inArray(event.which, options.keys.next) > -1;


### PR DESCRIPTION
Without this patch, deck.js was capturing ALT+arrow events which are
use by some people to navigate their browsing history (back/forward).