### PR TITLE
Discard a SecurityError raised when navigating on a local file, making navigation work again.

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -342,7 +342,11 @@ that use the API provided by core.
     removeContainerHashClass($.deck('getSlide', from).attr('id'));
     addContainerHashClass($.deck('getSlide', to).attr('id'));
     if (Modernizr.history) {
-      window.history.replaceState({}, "", hashPath);
+      // Raises a SecurityError when navigating, if the slides are opened locally.
+      try {
+        window.history.replaceState({}, "", hashPath);
+      } catch(e) {
+      }
     }
   };
 


### PR DESCRIPTION
Navigation doesn't work when the slides are opened "locally", as opposed to "served by a web server".
This issue has been observed in Chrome (Windows and MacOSX).

The reason is that window.history.replaceState() raises a SecurityError. Catching it fixes the navigation.
