### PR TITLE
Catch security exception when running in chrome from filesystem

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -342,7 +342,10 @@ that use the API provided by core.
     removeContainerHashClass($.deck('getSlide', from).attr('id'));
     addContainerHashClass($.deck('getSlide', to).attr('id'));
     if (Modernizr.history) {
-      window.history.replaceState({}, "", hashPath);
+      try {
+        window.history.replaceState({}, "", hashPath);
+      } catch (exception) {
+      }
     }
   };
 


### PR DESCRIPTION
boilerplate.html does not work in chrome when opened from filesystem. For some reason history is not available there.