### PR TITLE
Issue #187 Fixed local deck with Chrome

### DIFF
--- a/core/deck.core.js
+++ b/core/deck.core.js
@@ -341,7 +341,7 @@ that use the API provided by core.
 
     removeContainerHashClass($.deck('getSlide', from).attr('id'));
     addContainerHashClass($.deck('getSlide', to).attr('id'));
-    if (Modernizr.history) {
+    if (Modernizr.history && window.location.protocol != 'file:') {
       window.history.replaceState({}, "", hashPath);
     }
   };


### PR DESCRIPTION
I am not familiar with javascript and/or history api this pull request resolves the issue with Chrome. Unfortunately it prevents all use of replaceState while running local decks.